### PR TITLE
separated link for rss items

### DIFF
--- a/comedy-rss
+++ b/comedy-rss
@@ -66,7 +66,7 @@ for PIC in $PICS; do
   cat >> $FILE << ITEM
 <item>
 <title>$DESC</title>
-<link>$DIR_URL</link>
+<link>$DIR_URL/$PIC</link>
 <description>&lt;img src="$DIR_URL/$PIC"/&gt;</description>
 <pubDate>$LMD</pubDate>
 </item>


### PR DESCRIPTION
The firefox handle right the rss, but newsbeuter list only one.
I changed the link tag of the item to the same as the image 
link inside the description, I hope it will solve it.
