### PR TITLE
comedy-rss csv parsing

### DIFF
--- a/comedy-rss
+++ b/comedy-rss
@@ -1,4 +1,5 @@
 #!/bin/sh
+cd $(echo $0 | sed -r 's|^(.*/).+$|\1|')
 
 if [ "$1" = "-h" ]; then
 cat <<EOF
@@ -8,10 +9,6 @@ Options:
   -h               print this help and exit
   -d <dir-url>     url of the working directory
                    \$DIR_URL environment variable can be used instead
-  -l <dir-loc>     local directory where the pictures are stored
-                   \$DIR_LOC environment variable can be used instead
-  -i <input-csv>   input file to parse
-                   \$INPUT_CSV environment variable can be used instead
   -t <title>       title of the rss channel
                    default if 'comedy'
   -e <description> description of the rss channel
@@ -25,21 +22,13 @@ fi
 
 description='Napirajz @ comedy central'
 title='comedy'
+INPUT_CSV=mine.csv
+FILE=napi.rss
 
 while [ -n "$*" ]; do
   if [ "$1" = "-d" ]; then
     shift
     DIR_URL=$1
-    shift
-  fi
-  if [ "$1" = "-l" ]; then
-    shift
-    DIR_LOC=$1
-    shift
-  fi
-  if [ "$1" = "-i" ]; then
-    shift
-    INPUT_CSV=$1
     shift
   fi
   if [ "$1" = "-t" ]; then
@@ -62,14 +51,6 @@ done
 if [ -z "$DIR_URL" ]; then
   exit 1
 fi
-if [ -z "$DIR_LOC" ]; then
-  exit 1
-fi
-if [ -z "$INPUT_CSV" ]; then
-  exit 1
-fi
-
-FILE=`echo ${INPUT_CSV%.*}.rss`
 
 cat > $FILE << HEADER
 <?xml version="1.0"?>
@@ -83,7 +64,7 @@ HEADER
 
 IFS=';'
 while read PIC DATE SRC; do 
-  LMD=`ls -le $DIR_LOC/$PIC \
+  LMD=`ls -le $PIC \
   | sed -r 's/^[-a-z]+ +[0-9]+ +[a-z0-9]+ +[a-z0-9]+ +[0-9]+ +(.+) +[^ ]+$/\1/' \
   | sed -r 's/^(.+) (.+) (.+) (.+) (.+)$/\1, \3 \2 \5 \4 +0100/'`
   DESC=${PIC%.*}


### PR DESCRIPTION
comedy-rss parses mine.csv

$ ./comedy-rss -l /home/git/napi -d http://subogero.dyndns.org/git/napi/ -i mine.csv

That will create mine.rss, which holds all the work of grafitember

-l option add a local directory where the pictures can be found at the server.

If you could change the time format
2002_09_07 -> Sat, 07 Sep 2002 0:00:01 GMT
then the ls command can be skipped in comedy-rss
