### PR TITLE
Fixed index parsing

### DIFF
--- a/frissit
+++ b/frissit
@@ -35,7 +35,7 @@ if [ "$1" != -n -a "$1" != -c ]; then
   URLS=`curl -f http://index.hu/napirajz/ 2>/dev/null | sed -rn '/h1 class="blog-poszt-cim"/,/<\/a>/p' | sed -rn 's/^.*(http.+)".*$/\1/p'`
   for URL in $URLS; do
     curl -f ${URL} 2>/dev/null \
-    | sed -rn '/div class="lead"/,/div>/p; s/^.*og:(title|image).+="(.+)".*$/\1 \2/p;' >tmp
+    | sed -rn '/div class="lead"/,/div>/p; s/^.*og:(title).+="(.+)".*$/\1 \2/p; s/^.*span class="(image)holder ".*src="([^";]+).*$/\1 \2/p;' >tmp
     [ `ls -l tmp | awk '{ print $5 }'` = 0 ] && echo >&2 "No pics found" && continue
     ALT=`sed -rn 's|^title ||p' tmp | sed -r 's/[ .?!/]|&.+?;/_/g'`
     URL=`sed -rn 's|^image ||p' tmp | tail -1`


### PR DESCRIPTION
Helló Mester!

Az utóbbi időben azt vettem észre, hogy Grafit rövideket rajzol aztán rájöttem, hogy az indexes fiúk valamit változtattak a kimeneten így csak az indexképek vannak lehúzva. Ez a PR fixeli a problémát. 

Lehet át kellene térni valami szofisztikáltabb HTML parsolásra, mert ha valami újsort beraknak akkor megáll mint a gerely, de azt is lehet egyelőre jól van ez így, nem az űrbe megy. 