### PR TITLE
Fixing index.hu parsing Vol II.

### DIFF
--- a/frissit
+++ b/frissit
@@ -39,6 +39,9 @@ if [ "$1" != -n -a "$1" != -c ]; then
     [ `ls -l tmp | awk '{ print $5 }'` = 0 ] && echo >&2 "No pics found" && continue
     ALT=`sed -rn 's|^title ||p' tmp | sed -r 's/[ .?!/]|&.+?;/_/g'`
     URL=`sed -rn 's|^image ||p' tmp | tail -1`
+    if [[ $URL != "http*" ]]; then
+        URL="http:"$URL
+    fi
     PIC=`sed -rn 's|^image .+/||p' tmp | tail -1`
     ADD=`sed -rn 's/^ *(.*[^ ]) *<\/div> */\1/p' tmp`
     [ -z $ALT ] && continue


### PR DESCRIPTION
Üdv Mester!

Az indexesek megint tettek egy csavart az oldalukba: az img tagek src attribútuma elől elkezdték kihagyni a http: előtagot. A wget nálam csúnyán kiborult emiatt ezért bátorkodtam megírni eme PR-t ami e hiányosságot hivatott fixelni. 

A subogeron látom megborult a rend a témában, abban nem vagyok 100% biztos, hogy csak emiatt. Mindenesetre ez a fix szerintem segít.

